### PR TITLE
use shlex split

### DIFF
--- a/step-broker/kubernetes.py
+++ b/step-broker/kubernetes.py
@@ -39,9 +39,10 @@ def create_job(job_id, docker_img, cmd, volumes, env_vars, namespace):
         }
     }
 
+    import shlex
     if cmd:
         (job['spec']['template']['spec']['containers']
-         [0]['command']) = cmd.split()
+         [0]['command']) = shlex.split(cmd)
 
     if env_vars:
         job['spec']['template']['spec']['containers'][0]['env'] = []


### PR DESCRIPTION
using `string.split` breaks when using command lines that have whitespace in quotes such as `sh -c 'echo hello world'`

Changed to use `shlex.split`